### PR TITLE
remove required ruby version

### DIFF
--- a/lib/ruby3_backward_compatibility.rb
+++ b/lib/ruby3_backward_compatibility.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-module Ruby3BackwardCompatibility
-  NOT_GIVEN = Object.new
+if RUBY_VERSION.start_with?('3')
+  module Ruby3BackwardCompatibility
+    NOT_GIVEN = Object.new
 
-  # TODO private?
+    # TODO private?
+  end
+
+  require 'ruby3_backward_compatibility/callable_with_hash'
+  require 'ruby3_backward_compatibility/version'
 end
-
-require 'ruby3_backward_compatibility/callable_with_hash'
-require 'ruby3_backward_compatibility/version'

--- a/ruby3-backward-compatibility.gemspec
+++ b/ruby3-backward-compatibility.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Backward compatibility for Ruby 3 stdlib'
   spec.homepage      = 'https://github.com/makandra/ruby3-backward-compatibility'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/makandra/ruby3-backward-compatibility'


### PR DESCRIPTION
We're integrating this at the moment, our release strategy is to bundle for both ruby versions and incrementally scale up the ruby 3 instances. This change would enable us to use the same Gemfile without a custom group and build time logic.