### PR TITLE
Add support for Object#=~ method

### DIFF
--- a/lib/ruby3_backward_compatibility/compatibility/object.rb
+++ b/lib/ruby3_backward_compatibility/compatibility/object.rb
@@ -8,6 +8,10 @@ module Ruby3BackwardCompatibility
     def untaint
       self
     end
+
+    def =~(*)
+      nil
+    end
   end
 end
 

--- a/spec/ruby3_backward_compatibility/compatibility/object_spec.rb
+++ b/spec/ruby3_backward_compatibility/compatibility/object_spec.rb
@@ -15,5 +15,12 @@ module Ruby3BackwardCompatibility
         expect(object.untaint).to eq(object)
       end
     end
+
+    describe '#=~' do
+      it 'returns nil' do
+        object = Object.new
+        expect(object =~ object).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
Object#=~ was present till ruby 3.1.4 but was removed in 3.2.2. It was a dummy method which always returned nil.

Following code will work in ruby 3.1.4 but breaks in ruby 3.2.2
```
1 =~ 2
```
Reference:
ruby 3.1.4 -  https://ruby-doc.org/3.1.4/Object.html#method-i-3D~
