### PR TITLE
support newer major ruby versions

### DIFF
--- a/lib/ruby3_backward_compatibility.rb
+++ b/lib/ruby3_backward_compatibility.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if RUBY_VERSION.to_i >= 3
-  module Ruby3BackwardCompat(bility
+  module Ruby3BackwardCompatibility
     NOT_GIVEN = Object.new
   end
 

--- a/lib/ruby3_backward_compatibility.rb
+++ b/lib/ruby3_backward_compatibility.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-if RUBY_VERSION.start_with?('3')
-  module Ruby3BackwardCompatibility
+if RUBY_VERSION.to_i >= 3
+  module Ruby3BackwardCompat(bility
     NOT_GIVEN = Object.new
   end
 


### PR DESCRIPTION
Trying to require this gem from Ruby 4 breaks because the condition evaluates to false. Despite the gem name I think it's fair to extend it to "3 or newer"?